### PR TITLE
Allow templating target url in http action

### DIFF
--- a/src/actions/action_http.py
+++ b/src/actions/action_http.py
@@ -23,12 +23,16 @@ class HttpAction(Action):
         if self.body and 'Content-Length' not in headers:
             headers['Content-Length'] = str(len(self.body))
 
-        response = requests.request(self.method, self.target, headers=headers, data=self._body)
+        response = requests.request(self.method, self._target, headers=headers, data=self._body)
 
         if self.fail_on_error and response.status_code // 100 != 2:
             self.error('HTTP call failed (HTTP %d)' % response.status_code)
 
         print(self._render_with_template(self.output_format, response=response))
+
+    @property
+    def _target(self):
+        return self._render_with_template(self.target)
 
     @property
     def _headers(self):

--- a/tests/test_http_action.py
+++ b/tests/test_http_action.py
@@ -128,6 +128,12 @@ class HttpActionTest(ActionTestBase):
         self.assertIn('H accept=text/plain', output)
         self.assertIn('H x-test=test_get_method', output)
 
+    def test_target_replacement(self):
+        output = self._invoke_http(
+                target='/some/{{ "remote" }}/endpoint')
+
+        self.assertIn('uri=/some/remote/endpoint', output)
+
     def test_header_replacement(self):
         output = self._invoke_http(
             headers={'X-Original-Path': '{{ request.path }}'})


### PR DESCRIPTION
For example, this allows using `read_config` to read the url from an env variable or docker secret.