### PR TITLE
Allow generating json output via yaml for http action

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,12 @@ _Jinja2_ template as `response`.
 
 | key | description | default | templated | required |
 | --- | ----------- | ------- | --------- | -------- |
-| target  | The target endpoint as `<scheme>://<host>[:<port>][/<path>]` |    | no  | yes |
-| method  | The HTTP method to use for the request                  | `POST`  | no  | no  |
-| headers | The HTTP headers (as dictionary) to add to the request  | `empty` | yes | no  |
-| body    | The HTTP body (as string) to send with the request      | `empty` | yes | no  |
-| output  | Output template for printing the response on the standard output | `HTTP {{ response.status_code }} : {{ response.content }}` | yes | no |
+| target  | The target endpoint as `<scheme>://<host>[:<port>][/<path>]`                        |    | no  | yes |
+| method  | The HTTP method to use for the request                                              | `POST`  | no  | no  |
+| headers | The HTTP headers (as dictionary) to add to the request                              | `empty` | yes | no  |
+| json    | whether to dump `body` YAML subtree as json                                         | `False` | no  | no  |
+| body    | The HTTP body to send with the request. String (or YAML tree, if `json` is `True`)  | `empty` | yes | no  |
+| output  | Output template for printing the response on the standard output                    | `HTTP {{ response.status_code }} : {{ response.content }}` | yes | no |
 
 #### github-verify
 

--- a/tests/test_http_action.py
+++ b/tests/test_http_action.py
@@ -140,6 +140,13 @@ class HttpActionTest(ActionTestBase):
 
         self.assertIn('B original={"request": {"path": "/testing"}}', output)
 
+    def test_json_output_with_replacement(self):
+        output = self._invoke_http(
+            json=True,
+            body={'original': {'request': {'path': '{{ request.path }}'}}})
+
+        self.assertIn('B original={"request": {"path": "/testing"}}', output)
+
     def test_output_formatting(self):
         output = self._invoke_http(
             output='HTTP::{{ response.status_code }}')


### PR DESCRIPTION
Example

```yaml
  actions:
    - http:
        target: https://my/url
        headers:
          "Content-Type": "application/json"
        json: true
        body:
          activity: "{{ request.json.pusher.username }} pushed to {{ request.json.repository.name }}"
          title: "{{ request.json.commits | count }} new commits on {{ request.json.ref | replace('refs/heads/', '') }}"
          message: |
              {% for commit in request.json.commits %}
                [{{ commit.id[0:12] }}]({{ commit.url }}): {{ commit.message }}
              {% endfor %}
```